### PR TITLE
Fix `SoftEmbedding` class argument handling

### DIFF
--- a/megatron/model/word_embeddings.py
+++ b/megatron/model/word_embeddings.py
@@ -194,10 +194,11 @@ class SoftEmbedding(torch.nn.Module):
         super(SoftEmbedding, self).__init__()
         self.n_tokens = n_tokens
         self.neox_args = neox_args
-        self.init_range = init_range
+        self.random_range = init_range
         self.init_string = init_string
+        self.embedding_module = wte
         self.soft_embedding_weight = torch.nn.parameter.Parameter(
-            self.initialize_embedding(wte)
+            self.initialize_embedding()
         )
 
     def initialize_embedding(self):
@@ -213,7 +214,7 @@ class SoftEmbedding(torch.nn.Module):
                     : self.n_tokens, :
                 ]  # pad up to n_tokens
             return embeds
-        return torch.Tensor(n_tokens, neox_args.hidden_size).uniform_(
+        return torch.Tensor(self.n_tokens, self.neox_args.hidden_size).uniform_(
             -self.random_range, self.random_range
         )
 


### PR DESCRIPTION
A small change to make the `SoftEmbedding` class usable inside of our pipeline.